### PR TITLE
add util to convert burp or HAR files to Probely's navigation sequences

### DIFF
--- a/utils/README-burp_har_to_navigation_seq.md
+++ b/utils/README-burp_har_to_navigation_seq.md
@@ -1,0 +1,43 @@
+# Burp and HAR files converter
+
+## Converts Burp or HAR files to Probely's Navigation sequences.
+
+### Required options
+
+ - `--type/-t`: `burp` or `har` (input file format)
+ - `--input/-i`: `/path/to/original_file`
+ - `--output/-o`: `/path/to/destination_file`
+
+### Optional
+
+- `--crawl` or `--no-crawl` (default: `crawl`)
+
+### From Burp file to Probely's Navigation sequence
+
+```sh
+$ python3 ./burp_har_to_navigation_seq.py -t burp -i /tmp/burp_exported_file.xml -o /tmp/probely_navigation.json
+```
+
+
+### From HAR file to Probely's Navigation sequence
+
+```sh
+$ python3 ./burp_har_to_navigation_seq.py -t har -i /tmp/har_exported_file.har -o /tmp/probely_navigation.json
+```
+
+```sh
+$ python3 ./burp_har_to_navigation_seq.py -h 
+usage: burp_har_to_navigation_seq.py [-h] -t {burp,har} -i INPUT -o OUTPUT [--crawl | --no-crawl]
+
+Converts Burp or HAR files to Probely's navigation sequences
+
+options:
+  -h, --help            show this help message and exit
+  -t {burp,har}, --type {burp,har}
+                        burp/har
+  -i INPUT, --input INPUT
+                        Input file
+  -o OUTPUT, --output OUTPUT
+                        Output file
+  --crawl, --no-crawl   Crawl the requests
+```

--- a/utils/burp_har_to_navigation_seq.py
+++ b/utils/burp_har_to_navigation_seq.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+"""
+Converts Burp or HAR files to Probely's Navigation sequences.
+"""
+import argparse
+import json
+
+def run():
+    parser = argparse.ArgumentParser(description='Converts Burp or HAR files to Probely\'s navigation sequences')
+    parser.add_argument('-t', '--type', help='burp/har', choices=['burp', 'har'], required=True)
+    parser.add_argument('-i', '--input', help='Input file', type=argparse.FileType('r'), required=True)
+    parser.add_argument('-o', '--output', help='Output file', type=argparse.FileType('w'), required=True)
+    parser.add_argument('--crawl', help='Crawl the requests', default=True, action=argparse.BooleanOptionalAction)
+    args = parser.parse_args()
+
+    with args.input as file:
+        input_data = file.read()
+
+    if args.type == 'burp':
+        out_data = [{
+            'file_type': 'burp',
+            'crawl': args.crawl,
+            'file_data': input_data
+        }]
+    elif args.type == 'har':
+        out_data = [{
+            'file_type': 'har',
+            'crawl': args.crawl,
+            'file_data': input_data
+        }]
+
+    final_json = json.dumps(out_data, indent=2)
+    args.output.write(final_json)
+
+    print('Done.')
+    print('File converted to file: {}'.format(args.output.name))
+
+
+if __name__ == '__main__':
+    run()


### PR DESCRIPTION
### Required options

 - `--type/-t`: `burp` or `har` (input file format)
 - `--input/-i`: `/path/to/original_file`
 - `--output/-o`: `/path/to/destination_file`

### Optional

- `--crawl` or `--no-crawl` (default: `crawl`)

### From Burp file to Probely's Navigation sequence

```sh
$ python3 ./burp_har_to_navigation_seq.py -t burp -i /tmp/burp_exported_file.xml -o /tmp/probely_navigation.json
```


### From HAR file to Probely's Navigation sequence

```sh
$ python3 ./burp_har_to_navigation_seq.py -t har -i /tmp/har_exported_file.har -o /tmp/probely_navigation.json
```